### PR TITLE
Fix ClassRegistry import error

### DIFF
--- a/vot/utilities/__init__.py
+++ b/vot/utilities/__init__.py
@@ -602,7 +602,7 @@ class Registry(ClassRegistry):
             group (str): The name of the entry point group that will be used to load new classes.
             attr_name (typing.Optional[str], optional): If set, the registry will "brand" each class with its corresponding registry key. Defaults to None.
         """
-        from class_registry import EntryPointClassRegistry
+        from class_registry.entry_points import EntryPointClassRegistry
         super(Registry, self).__init__(group, attr_name)
         self._entry_point = EntryPointClassRegistry(group=group, attr_name=attr_name)
 


### PR DESCRIPTION
This fixes the error brought up in https://github.com/votchallenge/toolkit/issues/133. Previously, running vot initialize would result in the following error due to breaking changes mentioned here: https://classregistry.readthedocs.io/en/latest/upgrading_to_v5.html#imports

```
cannot import name 'EntryPointClassRegistry' from 'class_registry' (/usr/local/lib/python3.11/dist-packages/class_registry/__init__.py)
```